### PR TITLE
Change noted output of generator iterator example

### DIFF
--- a/tutorials/02-functions/05-generators.md
+++ b/tutorials/02-functions/05-generators.md
@@ -42,7 +42,7 @@ Generators return an object with two properties, the `value` emitted by the curr
 We can also iterate over all of the values in a generator:
 
 ```js
-for (x of generator) { console.log(x); }; // Logs 2, 4, 6
+for (x of generator) { console.log(x); }; // Logs 4, 6, 8
 ```
 
 We can also create a generator function that yields values indefinitely. Let's create a simple counter generator that will always generate the next increment indefinitely.


### PR DESCRIPTION
generator was passed 2, not zero, so the output would be 4, 6, and 8, rather than 2, 4, and 6.
