### PR TITLE
Edits and updates for tutorials 01 and 02

### DIFF
--- a/tutorials/01-array-prototype-methods/01-additional-methods.md
+++ b/tutorials/01-array-prototype-methods/01-additional-methods.md
@@ -1,6 +1,6 @@
 # Addition Array.prototype methods
 
-`Array.prototype` has a number of other methods beyond what we have discussed in depth above. You can find the full list of methods [at the Mozilla Developer Network page for `Array`][mdn-array]. Below are a few additional methods that are particularly useful.
+`Array.prototype` has a number of other methods beyond what we have discussed in depth above. You can find the full list of methods at [the Mozilla Developer Network page for `Array`][mdn-array]. Below are a few additional methods that are particularly useful.
 
 [mdn-array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
 
@@ -8,7 +8,7 @@
 
 [`Array.prototype.some()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) and [`Array.prototype.every()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every) are used to determine if some or all — respectively — of the elements meet a given criteria. Like `filter()`, `some()` and `every()` take a callback function that returns either a truthy or falsy value. While `filter()` returns a new array, however, `some()` and `every()` return a boolean that indicates the result of the test:
 
-```js
+```javascript
 function isOdd(number) {
   return !!(number % 2);
 }
@@ -28,7 +28,7 @@ function isOdd(number) {
 
 [`Array.prototype.concat()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat) defines additional values and arrays and adds them onto the array on which it is called.
 
-```js
+```javascript
 const stringedInstruments = ['guitar', 'bass', 'harp'];
 const percussionInstruments = ['bongos', 'snare drum', 'bass drum'];
 
@@ -42,7 +42,7 @@ console.log(instruments);
 
 Often we will want to know if a certain element is in an array. In these cases, we can use [`Array.prototype.indexOf()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf) to find the index of a given element.
 
-```js
+```javascript
 const letters = ['a', 'b', 'c'];
 
 letters.indexOf('a'); // returns 0;
@@ -51,13 +51,13 @@ letters.indexOf('b'); // returns 1;
 
 In the event that an element is not in the array, `indexOf()` will return `-1` (it can't return `0` — a falsy value — because `0` is a valid array index, hence using -1 in this case.) To assert that an element is in the array, we can check to make sure its index is _not_ `-1`.
 
-```js
+```javascript
 ['a', 'b', 'c'].indexOf('a') !== -1;
 ```
 
 Conversely, if we want to check that an element is not in an array, we can assert that it has an index of `-1`;
 
-```js
+```javascript
 ['a', 'b', 'c'].indexOf('not in here') === -1;
 ```
 
@@ -65,13 +65,14 @@ Conversely, if we want to check that an element is not in an array, we can asser
 
 [`Array.prototype.slice()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice) returns a copy of a given array. It takes two optional arguments: a starting index and an ending index. If we give `slice` a starting index it will return a copy of the array from that starting index forward. If we provide it a starting and ending index, it will return an array of the elements between those two indexes. If we give `slice()` a negative starting index, it will start from the end of the array and work backwards.
 
-```js
+```javascript
 const numbers = [1, 2, 3, 4, 5, 6];
 
+numbers.slice();     // [1, 2, 3, 4, 5, 6]
 numbers.slice(0);    // [1, 2, 3, 4, 5, 6]
 numbers.slice(1);    // [2, 3, 4, 5, 6]
 numbers.slice(2);    // [3, 4, 5, 6]
-numbers.slice(-2);    // [5, 6]
+numbers.slice(-2);   // [5, 6]
 numbers.slice(2, 4); // [3, 4];
 ```
 
@@ -79,7 +80,7 @@ In JavaScript there are some collections that are not instances of `Array` and �
 
 The most common use of this technique is with the `arguments` object that is available to every function in JavaScript.
 
-```js
+```javascript
 function exampleFunction() {
   console.log(arguments);
 }
@@ -89,7 +90,7 @@ exampleFunction(1, 2, 3); // Logs [1, 2, 3]
 
 At first glance, `arguments` looks suspiciously like an array, but it isn't and — more importantly — it does not inherit from `Array.prototype`.
 
-```js
+```javascript
 console.log(arguments.forEach); // undefined
 console.log(arguments.map); // undefined
 console.log(arguments.reduce); // undefined
@@ -97,7 +98,7 @@ console.log(arguments.reduce); // undefined
 
 If we tried to use `forEach()` try to iterate over each of the arguments passed to the array, it would raise an error.
 
-```js
+```javascript
 function exampleFunction() {
   arguments.forEach(function (argument) {
     console.log(argument)
@@ -109,7 +110,7 @@ exampleFunction(1, 2, 3); // TypeError: arguments.forEach is not a function.
 
 The common solution is to simply convert `arguments` into an array — which, in turn, would inherit from `Array.prototype`.
 
-```js
+```javascript
 function exampleFunction() {
   const args = Array.prototype.slice.call(arguments);
   args.forEach(function (argument) {

--- a/tutorials/02-functions/01-calling-functions.md
+++ b/tutorials/02-functions/01-calling-functions.md
@@ -4,7 +4,7 @@ Functions in JavaScript are little units of code that can be executed later and 
 
 Here is a simple example of a function that takes a single argument and logs a message to the console, just in case you are in the dark as to what a function looks like:
 
-```js
+```javascript
 function sayHello(name) {
     console.log('Hello, ' + name + '.');
 }
@@ -16,7 +16,7 @@ There a two major ways of defining functions in JavaScript: _function declaratio
 
 First, let's take a look at each in practice.
 
-```js
+```javascript
 // Function declaration
 function logSomething(something) {
   console.log(something);
@@ -34,7 +34,7 @@ Function declarations are hoisted to the top of the scope, which means that you 
 
 Let's look at an example:
 
-```js
+```javascript
 logSomethingDeclaration('This works.');
 console.log(typeof logSomethingDeclaration); // "function"
 
@@ -54,7 +54,9 @@ var logSomethingExpression = function (something) {
 };
 ```
 
-We'll revisit some of the other differences between function declarations and expressions later on when we discuss [recursion](#Recursion).
+We'll revisit some of the other differences between function declarations and expressions later on when we discuss [recursion][].
+
+[recursion]: https://github.com/mdn/advanced-js-fundamentals-ck/blob/gh-pages/tutorials/02-functions/04-recursion.md#function-declarations-function-expressions-and-recursion
 
 ## Invoking functions
 
@@ -64,7 +66,7 @@ Let's now take a look at the intricacies of function invocation.
 
 The easiest way to call a function is to append a pair of parentheses to the end of the name assigned to the function.
 
-```js
+```javascript
 function sayHello(name) {
     console.log('Hello!');
 }
@@ -76,7 +78,7 @@ Functions are incredibly flexible in JavaScript. Not only can we call them like 
 
 We can refer to a function without calling it by omitting the parentheses (you'll sometimes see the parentheses referred to as the "function invocation operator").
 
-```js
+```javascript
 var myFavoriteFunction = sayHello;
 ```
 
@@ -84,7 +86,7 @@ In the first section of this content kit, we passed functions to methods on `Arr
 
 We omit the parentheses in this context because we're referencing it, but not invoking it. For example:
 
-```js
+```javascript
 function doubleNumber(n) {
   return n * 2;
 }
@@ -92,11 +94,11 @@ function doubleNumber(n) {
 [1,2,3].map(doubleNumber);
 ```
 
-If we did add the parentheses to `doubleNumber()`, JavaScript would evaluate the function and place its return value as the argument being passed to `c`. It's also worth noting that if you do invoke the function without passing an argument, the function will attempt to multiply `undefined` by `2`. This will result in `NaN`, which stands for "not a number" and is also not a function that `Array.prototype.map()` can call — as a result the browser will throw an error.
+If we did add the parentheses to `doubleNumber()`, JavaScript would evaluate the function and place its return value as the argument being passed to `c`. It's also worth noting that if you do invoke the function without passing an argument, the function will attempt to multiply `undefined` by `2`. This will result in `NaN`, which stands for "not a number" and is also not a function that `Array.prototype.map()` can call — as a result the code will throw an error.
 
 Consider the following:
 
-```js
+```javascript
 function returnSomething(something) {
   return something;
 };
@@ -123,7 +125,7 @@ At this point we've explored one way of invoking a function — adding a pair of
 
 However, something special happens when we declare a function as a property on a object.
 
-```js
+```javascript
 function logThis() {
   console.log(this);
 }
@@ -149,7 +151,7 @@ When functions are set as the values of object properties, they adapt to their n
 
 Implement the following function:
 
-```js
+```javascript
 function logFoo() {
   console.log(this.foo);
 }

--- a/tutorials/02-functions/02-what-is-this.md
+++ b/tutorials/02-functions/02-what-is-this.md
@@ -1,12 +1,13 @@
 # What is `this`?
 
-In the examples above, we used a special property in JavaScript called `this`. `this` is not only very hard to talk about in English, it's a concept that can be confusing to many new JavaScript developers. We'll be dealing with `this` a lot in the next few sections, so it's probably best that we spend a little time talking about it now.
-
+In the [last tutorial][calling-functions], we used a special property in JavaScript called `this`. `this` is not only very hard to talk about in English, it's a concept that can be confusing to many new JavaScript developers. We'll be dealing with `this` a lot in the next few sections, so it's probably best that we spend a little time talking about it now.
 The short and not very helpful version is that `this` refers to the _context_ in which a function was _invoked_ in JavaScript. This is different from where it was _defined_.
+
+[calling-functions]: https://github.com/mdn/advanced-js-fundamentals-ck/blob/gh-pages/tutorials/02-functions/01-calling-functions.md#methods
 
 Let's look at an example:
 
-```js
+```javascript
 function logThis() {
   console.log(this);
 }
@@ -14,8 +15,8 @@ function logThis() {
 logThis(); // logs `window` in the browser or `global` in Node
 
 var someObj = {
-  log: logThis;
-}
+  log: logThis
+};
 
 someObj.log(); // logs `someObj`
 ```
@@ -24,7 +25,7 @@ This gives you a basic idea of what `this` is, but sometimes things get more com
 
 ## rules for `this`
 
-Below we'll look at a couple of rules we can follow to make things easier. 
+Below we'll look at a couple of rules we can follow to make things easier.
 
 ### Rule 1: Unless another rule says otherwise, `this` is the global object
 
@@ -52,7 +53,7 @@ Functions in JavaScript are objects and share methods on `Function.prototype` �
 
 One method all functions share is `call()`, which uses the first argument you hand it and sets it to `this`, it then takes all subsequent arguments and passes them to the function you're calling `call()` on. It basically provides a way to call any function on a specific function scope.
 
-```js
+```javascript
 function addToFoo(n) {
   return this.foo + n;
 }
@@ -69,9 +70,17 @@ addToFoo.call({ foo: 3 }, 2); // adds 2 to the `foo` property on a new object
 
 The first argument when we use the `call()` method is used to set `this`. The second argument is passed to the function we're calling as its first argument. If we had a third argument, it would be passed as the second argument to the function we're calling and so on.
 
+Remember that in JavaScript you can pass an arbitrary number of arguments to a function and it will simply ignore the ones it doesn't need. Thus, the following would also be a valid use of `call()`
+
+```javascript
+addToFoo.call(bar, 2, 'extra arg'); // adds 2 to the `foo` property on `bar` and
+                                    // returns 3; ignores the third argument
+                                    // since `addToFoo` takes only one
+```
+
 `apply()` is another method shared by all functions and it behaves in a very similar fashion to `call()`, except that it takes the arguments you'd like to pass to the function as an array.
 
-```js
+```javascript
 function addThreeNumbersToFoo(first, second, third) {
   return this.foo + first + second + third;
 }
@@ -85,14 +94,18 @@ addThreeNumbersToFoo.apply({ foo: 1 }, [1, 1, 1]); // returns 4
 
 `call()` and `apply()` allow us to have a say as to the mercurial binding of `this`. Regardless of the first and second rules, if we explicitly set the value of `this` using `call()` or `apply()`, then that's the value of `this` inside of that function.
 
-There is a fourth rule, but we'll have to wait until we discuss object-oriented JavaScript later on before we say anymore about it.
+There is a [fourth rule][], but we'll have to wait until we discuss [object-oriented JavaScript][] later on before we say anymore about it.
+
+[fourth rule]: https://github.com/mdn/advanced-js-fundamentals-ck/blob/gh-pages/tutorials/03-object-oriented-javascript/01-introduction-to-object-oriented-javascript.md#functions-and-this-revisited
+
+[object-oriented JavaScript]: https://github.com/mdn/advanced-js-fundamentals-ck/tree/gh-pages/tutorials/03-object-oriented-javascript
 
 
 ## Using `apply()` to spread an array of arguments
 
 As we've seen `apply()` — like `call()` — is useful for explicitly setting `this`. Additionally, `apply()` is useful when we have an array that we'd like to spread out over the arguments of a function. Here's a quick example:
 
-```js
+```javascript
 function addThreeNumbers(first, second, third) {
   return first + second + third;
 }
@@ -106,21 +119,21 @@ Here the `numbers` array is being split up into three separate values that are  
 
 Now consider the `Math.min()` function. It takes a set of numbers as arguments and returns the smallest number. It can take any number of arguments.
 
-```js
+```javascript
 Math.min(1, 4, 10, 2); // returns 1
 Math.min(2, 3, 10, 100, 2048, 1984, 2012, 919); // returns 2
 ```
 
 What if we had an array of numbers?
 
-```js
+```javascript
 var numbers = [201, 100, 2];
 Math.min(numbers); // returns NaN
 ```
 
 `numbers` is an array and `Math.min` doesn't know how to deal with an array. We could try the following:
 
-```js
+```javascript
 var numbers = [201, 100, 2];
 Math.min(numbers[0], numbers[1], numbers[2]); // returns 2;
 ```
@@ -129,7 +142,7 @@ This works, but it relies us having a manageable number of items in the array. W
 
 `apply()` will take the items in the array and spread them out over the arguments of the array. We don't have to access each element by its index, which means we also don't have to know how many elements are in the array.
 
-```js
+```javascript
 var numbers = [2, 3, 10, 100, 2048, 1984, 2012, 919];
 
 Math.min.apply(null, numbers); // returns 2;
@@ -137,9 +150,9 @@ Math.min.apply(null, numbers); // returns 2;
 
 ### A word on the spread operator in ES6/2015
 
-ES6 introduces the spread operator (`...`), which allows us to spread the contents of an array without using `apply()`. In the future, you'll be able to do the following:
+ES6 introduces the spread operator (`...`), which allows us to spread the contents of an array without using `apply()`. With ES6, you're able to do the following:
 
-```js
+```javascript
 var numbers = [2, 3, 10, 100, 2048, 1984, 2012, 919];
 
 Math.min(...numbers);
@@ -156,7 +169,7 @@ We used `null` in the example above because it doesn't matter what `this` is sin
 
 The following are all equivalent for the purposes of splitting up an array of values amongst a function's arguments:
 
-```js
+```javascript
 addThreeNumbers.apply(null, numbers);
 addThreeNumbers.apply(this, numbers);
 addThreeNumbers.apply('oogieboogie', numbers);
@@ -166,9 +179,9 @@ addThreeNumbers.apply('oogieboogie', numbers);
 
 `call()` and `apply()` are great ways of explicitly setting `this` when we call a function. Sometimes, however, we want to set `this` when we define a function, not when we call it.
 
-`call()` and `apply()` invoke the function immediately. `bind()` is different — it returns a copy of the function that takes the sometimes slippery `this` and replaces it with a hard set value that is above the three rules we set above.
+`call()` and `apply()` invoke the function immediately. `bind()` is different — it returns a copy of the function that takes the sometimes slippery `this` and replaces it with a hard set value that we give it.
 
-```js
+```javascript
 function logFoo() {
   console.log(this.foo);
 }
@@ -179,14 +192,14 @@ logFoo(); // undefined
 logFoo.call(someObject); // Hello
 
 var boundLogFoo = logFoo.bind(someObject); // returns a new function with
-                                           //`this` explicitly set
+                                           // `this` explicitly set
 
 boundLogFoo(); // Hello
 ```
 
 Let's take one more look at this with some objects.
 
-```js
+```javascript
 var fido = {
   name: 'Fido',
   sayHello: function () {
@@ -204,6 +217,7 @@ var haveTacoSayHello = fido.sayHello.bind({ name: 'Taco' });
 
 fido.sayHello(); // My name is Fido.
 spot.sayHello(); // My name is Spot.
+spot.boundSayHello(); // My name is Fido.
 haveTacoSayHello(); // My name is Taco.
 ```
 
@@ -215,7 +229,7 @@ The easiest way to stop `this` from changing under our feet is to take it out of
 
 Consider the following adaptation from an earlier example:
 
-```js
+```javascript
 function logThis() {
   console.log(this);
 }
@@ -225,7 +239,7 @@ Let's say that we wanted a version of this function where the value of `this` wa
 
 We could wrap our function in another function that would eventually use `call()` to explicitly set the value of `this`:
 
-```js
+```javascript
 function logThis() {
   console.log(this);
 }
@@ -240,9 +254,10 @@ logSandwich(); // 'sandwich'
 
 #### Keeping Our Code DRY
 
-This works, but it's also a little tedious to have to create new variables each time we need to explicitly bind `this` and return a new function. It's also not very reusable — if you recall from our section on currying, we can create a function that returns a function in order to keep our code DRY.
+This works, but it's also a little tedious to have to create new variables each time we need to explicitly bind `this` and return a new function. It's also not very reusable — if you recall from our [section on currying][currying], we can create a function that returns a function in order to keep our code DRY.
 
-```js
+[currying]: https://github.com/mdn/advanced-js-fundamentals-ck/blob/gh-pages/tutorials/02-functions/03-currying-and-partial-application.md
+```javascript
 function logThis() {
   console.log(this);
 }
@@ -264,7 +279,7 @@ logBurrito(); // 'burrito'
 
 We now have a reusable function that we can use to create new functions with the context explicitly bound. We're close to approximating the version that ships in [ECMAScript 5][ES5]. We don't want to override the method that comes built-in, so we'll call ours `Function.prototype.bindTo()`;
 
-```js
+```javascript
 Function.prototype.bindTo = function (context) {
   var fn = this;
   return function () {
@@ -287,7 +302,7 @@ logBurrito(); // 'burrito'
 
 Our new method mostly works, but there is one small problem: our implementation ignores any arguments that our function takes. This hasn't hurt us so far because `logThis()` didn't take any arguments. Let's do one final refactoring that will allow our explicitly-bound function to take the same arguments as the original function.
 
-```js
+```javascript
 Function.prototype.bindTo = function (context) {
   var fn = this;
   return function () {
@@ -322,7 +337,7 @@ Our custom `bind()` method isn't perfect. Most modern browsers ship with a `bind
 
 Let's take a look at an example without any asynchronous callbacks:
 
-```js
+```javascript
 var person = {
   firstName: 'Steve',
   lastName: 'Kinney',
@@ -339,7 +354,7 @@ This works as we expect. When we call `updateName()`, `this` is still in the con
 
 Things get a little tricker when we call an asynchronous function (like an AJAX call) and pass a callback.
 
-```js
+```javascript
 function somethingAsynchronous(callback) {
   console.log('Maybe we\'re fetching the new name from the server.');
   setTimeout(callback, 1000);
@@ -371,7 +386,7 @@ The end result is that not only did we not update the property we wanted to, but
 
 There are a few ways to handle this. While the callback loses its reference to `this`, it still has access to the scope that it came from. As a result, this would work:
 
-```js
+```javascript
 function somethingAsynchronous(callback) {
   console.log('Maybe we\'re fetching the new name from the server.');
   setTimeout(callback, 1000);
@@ -397,7 +412,7 @@ console.log(person.firstName); // This is now Wes.
 
 An alternate approach is to explicitly set the value of `this` on the callback function using `bind()`.
 
-```js
+```javascript
 function somethingAsynchronous(callback) {
   console.log('Maybe we\'re fetching the new name from the server.');
   setTimeout(callback, 1000);
@@ -419,3 +434,34 @@ console.log(person.firstName); // Wes.
 ```
 
 The example above works because we used `bind(this)` to explicitly set the value of `this` on the anonymous function while we're still in the scope of `person`. When the callback is eventually called, it remembers what `this` is because we bound it to the function.
+
+### A word on arrow functions in ES6/2015
+
+ES6 introduces (fat) arrow functions, which allow us to write functions with shorter syntax (among other things). ES6 arrow functions deserve a tutorial of their own, but the relevance to this example is that arrow functions also lexically bind the `this` value implicitly. With ES6, we could write:
+
+```javascript
+function somethingAsynchronous(callback) {
+  console.log('Maybe we\'re fetching the new name from the server.');
+  setTimeout(callback, 1000);
+}
+
+var person = {
+  firstName: 'Steve',
+  lastName: 'Kinney',
+  updateName: function () {
+    somethingAsynchronous(() => {
+      this.firstName = 'Wes'
+    });
+  }
+};
+
+person.updateName();
+// Wait a second…
+console.log(person.firstName); // Wes.
+```
+
+Notice that we used a fat arrow function (`() => {}`) as our callback inside of `somethingAsynchronous`. This syntax negates the need to set a variable equal to `this` or explicitly use `bind()`, as was done in the first and second solutions, respectively.
+
+You can [read more about arrow functions][mdn-arrow-functions] on MDN.
+
+[mdn-arrow-functions]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions

--- a/tutorials/02-functions/03-currying-and-partial-application.md
+++ b/tutorials/02-functions/03-currying-and-partial-application.md
@@ -5,9 +5,11 @@ Read on, my friends.
 
 ## Partial application
 
-Partial application is a technique that allows us to pre-fill arguments to a function. Earlier, we discussed how you can use `bind()` on functions in JavaScript to explicitly set the value of `this`. Like `call()`, `bind()` takes additional arguments and will set those arguments on the function it returns.
+Partial application is a technique that allows us to pre-fill arguments to a function. [In the previous section][What is this], we discussed how you can use `bind()` on functions in JavaScript to explicitly set the value of `this`. Like `call()`, `bind()` takes additional arguments and will set those arguments on the function it returns.
 
-```js
+[What is this]: https://github.com/mdn/advanced-js-fundamentals-ck/blob/gh-pages/tutorials/02-functions/02-what-is-this.md#explicitly-setting-context-with-bind
+
+```javascript
 function add(a, b) {
   return a + b;
 }
@@ -25,7 +27,7 @@ This technique allows us to remove repetition from our code and use functions as
 
 Given the following base functions:
 
-```js
+```javascript
 function add(a, b) {
   return a + b;
 }
@@ -44,7 +46,7 @@ Use partial application to create the following:
 
 ## Currying
 
-[Currying][] is a technique—similar to partial application, named after the famous mathematician, [Haskell Curry][hc] — after whom the [Haskell][] programming language is also named. With partial application, we took an existing function and returned a new function with one or more of the arguments applied. With function currying we apply each argument one at a time, returning a new function in the currying chain until all the arguments have been supplied.
+[Currying][]—named after the famous mathematician, [Haskell Curry][hc] (after whom the [Haskell][] programming language is also named)—is a technique similar to partial application. With partial application, we took an existing function and returned a new function with one or more of the arguments applied. With currying we apply each argument one at a time, returning a new function in the currying chain until all the arguments have been supplied.
 
 [Currying]: https://en.wikipedia.org/wiki/Currying
 [hc]: https://en.wikipedia.org/wiki/Haskell_Curry
@@ -52,7 +54,7 @@ Use partial application to create the following:
 
 A curried function is one that returns a new function for every argument that it takes. Consider our `addThreeNumbers()` function from an earlier section:
 
-```js
+```javascript
 function addThreeNumbers(first, second, third) {
   return first + second + third;
 }
@@ -62,7 +64,7 @@ addThreeNumbers(1, 2, 3); // returns 6
 
 To rewrite this function as a curried function, we need to have it return a new function for each argument.
 
-```js
+```javascript
 function curriedAddThreeNumbers(first) {
   return function (second) {
     return function (third) {
@@ -76,7 +78,7 @@ curriedAddThreeNumbers(1)(2)(3); // returns 6
 
 Let's break that out in order to get a better sense of what's happening.
 
-```js
+```javascript
 var firstArgumentApplied = curriedAddThreeNumbers(1); // returns a function
 var secondArgumentApplied = firstArgumentApplied(2); // returns a function
 var thirdArgumentApplied = secondArgumentApplied(3); // returns 6
@@ -86,7 +88,7 @@ var thirdArgumentApplied = secondArgumentApplied(3); // returns 6
 
 There is a principle in programming called "Don't Repeat Yourself" (DRY). If you find yourself writing the same code over and over again, then your code isn't DRY. Consider the following.
 
-```js
+```javascript
 function wrapInParagraphTags(body) {
   return '<p>' + body + '</p>';
 }
@@ -102,9 +104,9 @@ function wrapInListItemTags(body) {
 
 This example is deliberately simple, but it illustrates the idea of repetitive code. It's fair to assume that if we continued down this path, we'd end up with more than three functions.
 
-Let's say we wanted to change this code in some way (for example to include a `class` attribute for each tag.) We would have to update each function individually and each time we updated a function we would run the risk of making a mistake and introducing a bug into our code. Instead, we could use currying to make this more efficient and error-free:
+Let's say we wanted to change this code in some way (for example to include a `class` attribute for each tag.) We would have to update each function individually and each time we updated a function we would run the risk of making a mistake and introducing a bug into our code. Instead, we could use currying to make this more efficient, DRYer, and less susceptible to errors:
 
-```js
+```javascript
 function createCurriedWrapper(tagName) {
   return function (body) {
     return '<' + tagName + '>' + body + '</' + tagName + '>';
@@ -115,7 +117,7 @@ var wrapInParagraphTags = createCurriedWrapper('p');
 var wrapInHeaderTags = createCurriedWrapper('h1');
 var wrapInListItemTags = createCurriedWrapper('li');
 
-var h2 = createCurriedWrapper('h2')('Hello world');
+var h2 = createCurriedWrapper('h2')('Hello world'); // '<h2>Hello world</h2>'
 ```
 
 Now, if we needed to change the basic implementation of wrapping strings in HTML tags, we could make our changes in one place, `createCurriedWrapper`, which is the foundation for all of our specialized wrapping functions.

--- a/tutorials/02-functions/04-recursion.md
+++ b/tutorials/02-functions/04-recursion.md
@@ -4,9 +4,11 @@ A recursive function is a function that calls itself. Recursion is especially us
 
 The factorial `5!` is equivalent to `5 * 4 * 3 * 2 * 1` or 120.
 
-```js
+```javascript
 function factorial(n) {
-  if (n <= 1) { return 1 };
+  if (n <= 1) {
+    return 1;
+  };
   return n * factorial(n - 1);
 }
 
@@ -55,9 +57,11 @@ factorial(40000); //Still an error now, will work later
 
 Until JavaScript engines implement tail call optimization, if you have a recursive function which may make lots of nested calls you'll need to use a technique called trampolining. Trampolining basically turns a recursive function into a loop which iteratively calls a function and feeds back in the result until a function isn't returned.
 
-We used recursion in the section where we drew blocks to the canvas using `requestAnimationFrame()`. At the end of the function, we called `requestAnimationFrame()` again with a reference to the same `gameLoop()` function.
+We used recursion in the [section where we drew blocks to the canvas][requestAnimationFrame Section] using `requestAnimationFrame()`. At the end of the function, we called `requestAnimationFrame()` again with a reference to the same `gameLoop()` function.
 
-```js
+[requestAnimationFrame Section]: https://github.com/mdn/advanced-js-fundamentals-ck/blob/gh-pages/tutorials%2F03-object-oriented-javascript%2F03-canvas-and-object-oriented-javascript.md#requestanimationframe
+
+```javascript
 requestAnimationFrame(function gameLoop() {
   context.clearRect(0, 0, canvas.width, canvas.height);
   blocks.forEach(function (block) { block.draw().move(); });
@@ -82,9 +86,9 @@ A Fibonacci sequence is a series of numbers where the next number is the sum of 
 
 Can you write a function called `fibonacci()`, which takes a number as an argument and returns an array containing a Fibonacci sequence of that length?
 
-```js
-fibonacci(5); // returns [1, 1, 2, 3, 5]
-fibonacci(3); // returns [1, 1, 2]
+```javascript
+fibonacci(5);  // returns [1, 1, 2, 3, 5]
+fibonacci(3);  // returns [1, 1, 2]
 fibonacci(10); // returns [1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
 ```
 

--- a/tutorials/02-functions/05-generators.md
+++ b/tutorials/02-functions/05-generators.md
@@ -1,24 +1,27 @@
 # Generators
 
-When we call a function in JavaScript, it typically runs until it hits the end of the function or a `return` statement. Generators, which are new to [ES6/2015][], are functions that can be paused and restarted again, and can return values at multiple points in their execution.
+When we call a function in JavaScript, it typically runs until it hits the end of the function or a `return` statement. Generators, which are new to [ES6/2015][], are functions that can be paused and started again, and can return values at multiple points in their execution.
 
 [ES6/2015]: http://es6-features.org/#GeneratorFunctionIteratorProtocol
 
-Consider the `countdown()`, `fibonacci()`, and `factorial()` functions from the section on calling functions. We passed either a starting or stopping point to each function. Letting them run forever would be problematic. That said, it's conceivable to think that we might want to keep working with new factorials or numbers in a Fibonacci sequence as time goes on. This is a great use for generators.
+Consider the `countdown()`, `fibonacci()`, and `factorial()` functions from the section on [recursion][]. We passed either a starting or stopping point to each function. Letting them run forever would be problematic. That said, it's conceivable to think that we might want to keep working with new factorials or numbers in a Fibonacci sequence as time goes on. This is a great use for generators.
 
-**A note on browser support:** As of this writing (July 19, 2015) generator functions are supported by most of the recent versions of Chrome/Opera and Firefox as well as [io.js][]. They are not supported by Safari, Internet Explorer, or Node.js.
+[recursion]: https://github.com/mdn/advanced-js-fundamentals-ck/blob/gh-pages/tutorials/02-functions/04-recursion.md
 
-[io.js]:https://iojs.org/en/index.html
+**A note on browser support:** As of this writing (March 5, 2016) generator functions are supported by most of the recent versions of Chrome, Opera, Firefox, and Edge, as well as [node.js][]. They are not supported by Safari, or Internet Explorer. For a more comprehensive list of browser support for ES6, please consult this [table][es6-compat-table]
+
+[node.js]: https://nodejs.org/en/
+[es6-compat-table]: https://kangax.github.io/compat-table/es6/
 
 Generator functions look similar to regular functions, with the addition of an `*` after the `function` keyword.
 
-```js
+```javascript
 function* someGeneratorFunction() {};
 ```
 
 Calling a generator function returns a _Generator_ object. Generator objects have a `next()` method that either starts or resumes execution of the function until it hits the next `yield` statement.
 
-```js
+```javascript
 function* addTwoThreeTimes(addend) {
   yield addend + 2;
   yield addend + 2 + 2;
@@ -30,7 +33,7 @@ var generator = addTwoThreeTimes(2);
 
 We can now call the generator to get the next value.
 
-```js
+```javascript
 generator.next(); // { value: 4, done: false }
 generator.next(); // { value: 6, done: false }
 generator.next(); // { value: 8, done: false }
@@ -41,13 +44,13 @@ Generators return an object with two properties, the `value` emitted by the curr
 
 We can also iterate over all of the values in a generator:
 
-```js
+```javascript
 for (x of generator) { console.log(x); }; // Logs 4, 6, 8
 ```
 
 We can also create a generator function that yields values indefinitely. Let's create a simple counter generator that will always generate the next increment indefinitely.
 
-```js
+```javascript
 function* counterGenerator(count) {
   while (true) {
     yield count++;
@@ -66,7 +69,7 @@ counter.next() // { value: 6, done: false }
 // … and so on …
 ```
 
-Normally, `while (true)` would create an infinite loop and lock up the main thread indefinitely — bringing our program to a screeching halt. With a generator, the execution of the function is paused each time it hits the `yield` statement and control and ceded back to the scope in which it was called.
+Normally, `while (true)` would create an infinite loop and lock up the main thread indefinitely — bringing our program to a screeching halt and eventually blowing up in our faces when the call stack limit is reached. With a generator, the execution of the function is paused each time it hits the `yield` statement and control is ceded back to the scope in which it was called.
 
 This generator will continue generating values forever, but only when asked.
 
@@ -76,13 +79,13 @@ Let's create a generator function that will build a Fibonacci sequence one numbe
 
 Let's start by creating a new generator function called `fibonacciGenerator`:
 
-```js
+```javascript
 function* fibonacciGenerator() {};
 ```
 
 Fibonacci sequences are best expressed as an array of numbers. Let's instantiate an empty array. That we'll use to store our values.
 
-```js
+```javascript
 function* fibonacciGenerator() {
   var sequence = [];
 };
@@ -90,7 +93,7 @@ function* fibonacciGenerator() {
 
 We also know that we'd like to generate Fibonacci numbers indefinitely. We'll wrap our yield statement in a loop.
 
-```js
+```javascript
 function* fibonacciGenerator() {
   var sequence = [];
   while (true) {
@@ -101,11 +104,13 @@ function* fibonacciGenerator() {
 
 We can generate new numbers by adding the previous two together. In order to do that, we'll have to add `1` to the sequence if we have less than two numbers.
 
-```js
+```javascript
 function* fibonacciGenerator() {
   var sequence = [];
   while (true) {
-    if (sequence.length < 2) { sequence.push(1); }
+    if (sequence.length < 2) {
+      sequence.push(1);
+    }
     yield sequence;
   }
 };
@@ -113,7 +118,7 @@ function* fibonacciGenerator() {
 
 Now, it's time for the real work. If we have at least two numbers, we want to add the last two numbers together. Additionally, we're going to need the length of the sequence in multiple difference places, so we'll store it into a variable at the beginning of each loop.
 
-```js
+```javascript
 function* fibonacciGenerator() {
   var sequence = [];
   while (true) {
@@ -131,7 +136,7 @@ function* fibonacciGenerator() {
 
 We can now take our fibonacci generator for a spin and generate numbers to our heart's content.
 
-```js
+```javascript
 var fibonacci = fibonacciGenerator();
 
 fibonacci.next();
@@ -162,7 +167,7 @@ fibonacci.next();
 
 Can you create a generator function that can generate factorials? Below is an example of how the code should work when you have it up and running.
 
-```js
+```javascript
 function* factorialGenerator() {
   // Your code goes here.
 }


### PR DESCRIPTION
- Grammatical and indentation fixes
- use `javascript` instead of `js` to denote code snippets (wider parsing support across editors)
- Updates to ES6 features and browser support
- Fill in missing link tags
