### PR TITLE
Change `.apply()` on line 294 to `.call()`

### DIFF
--- a/tutorials/02-functions/02-what-is-this.md
+++ b/tutorials/02-functions/02-what-is-this.md
@@ -291,7 +291,7 @@ Our new method mostly works, but there is one small problem: our implementation 
 Function.prototype.bindTo = function (context) {
   var fn = this;
   return function () {
-    fn.apply(context, arguments);
+    fn.call(context, arguments);
   }
 }
 


### PR DESCRIPTION
On lines 306-308 we are passing individual arguments instead of an array of arguments.
